### PR TITLE
Fix AES decryption

### DIFF
--- a/src/Convey.Security/src/Convey.Security/IEncryptor.cs
+++ b/src/Convey.Security/src/Convey.Security/IEncryptor.cs
@@ -3,8 +3,6 @@ namespace Convey.Security;
 // AES-256
 public interface IEncryptor
 {
-    string Encrypt(string data, string key);
-    string Decrypt(string data, string key);
     byte[] Encrypt(byte[] data, byte[] iv, byte[] key);
     byte[] Decrypt(byte[] data, byte[] iv, byte[] key);
 }

--- a/src/Convey.Security/src/Convey.Security/Internals/Encryptor.cs
+++ b/src/Convey.Security/src/Convey.Security/Internals/Encryptor.cs
@@ -109,8 +109,8 @@ internal sealed class Encryptor : IEncryptor
         aes.Key = key;
         aes.IV = iv;
         var transform = aes.CreateDecryptor(aes.Key, aes.IV);
-        using var memoryStream = new MemoryStream(data);
-        using var cryptoStream = new CryptoStream(memoryStream, transform, CryptoStreamMode.Read);
+        using var memoryStream = new MemoryStream();
+        using var cryptoStream = new CryptoStream(memoryStream, transform, CryptoStreamMode.Write);
         cryptoStream.Write(data, 0, data.Length);
         cryptoStream.FlushFinalBlock();
 

--- a/src/Convey.Security/src/Convey.Security/Internals/Encryptor.cs
+++ b/src/Convey.Security/src/Convey.Security/Internals/Encryptor.cs
@@ -1,75 +1,24 @@
 using System;
 using System.IO;
-using System.Linq;
 using System.Security.Cryptography;
-using System.Text;
 
 namespace Convey.Security.Internals;
 
 internal sealed class Encryptor : IEncryptor
 {
-    public string Encrypt(string data, string key)
-    {
-        if (string.IsNullOrWhiteSpace(data))
-        {
-            throw new ArgumentException("Data to be encrypted cannot be empty.", nameof(data));
-        }
-
-        if (string.IsNullOrWhiteSpace(key))
-        {
-            throw new ArgumentException("Encryption key cannot be empty.", nameof(key));
-        }
-
-        using var aes = Aes.Create();
-        aes.Key = Encoding.UTF8.GetBytes(key);
-        var iv = Convert.ToBase64String(aes.IV);
-        var transform = aes.CreateEncryptor(aes.Key, aes.IV);
-        using var memoryStream = new MemoryStream();
-        using var cryptoStream = new CryptoStream(memoryStream, transform, CryptoStreamMode.Write);
-        using (var streamWriter = new StreamWriter(cryptoStream))
-        {
-            streamWriter.Write(data);
-        }
-
-        return iv + Convert.ToBase64String(memoryStream.ToArray());
-    }
-
-    public string Decrypt(string data, string key)
-    {
-        if (string.IsNullOrWhiteSpace(data))
-        {
-            throw new ArgumentException("Data to be decrypted cannot be empty.", nameof(data));
-        }
-
-        if (string.IsNullOrWhiteSpace(key))
-        {
-            throw new ArgumentException("Encryption key cannot be empty.", nameof(key));
-        }
-
-        using var aes = Aes.Create();
-        aes.Key = Encoding.UTF8.GetBytes(key);
-        aes.IV = Convert.FromBase64String(data.Substring(0, 24));
-        var transform = aes.CreateDecryptor(aes.Key, aes.IV);
-        using var memoryStream = new MemoryStream(Convert.FromBase64String(data.Substring(24)));
-        using var cryptoStream = new CryptoStream(memoryStream, transform, CryptoStreamMode.Read);
-        using var streamReader = new StreamReader(cryptoStream);
-
-        return streamReader.ReadToEnd();
-    }
-
     public byte[] Encrypt(byte[] data, byte[] iv, byte[] key)
     {
-        if (data is null || !data.Any())
+        if (data is null || data.Length == 0)
         {
             throw new ArgumentException("Data to be encrypted cannot be empty.", nameof(data));
         }
 
-        if (iv is null || !iv.Any())
+        if (iv is null || iv.Length == 0)
         {
             throw new ArgumentException("Initialization vector cannot be empty.", nameof(iv));
         }
 
-        if (key is null || !key.Any())
+        if (key is null || key.Length == 0)
         {
             throw new ArgumentException("Encryption key cannot be empty.", nameof(key));
         }
@@ -80,27 +29,25 @@ internal sealed class Encryptor : IEncryptor
         var transform = aes.CreateEncryptor(aes.Key, aes.IV);
         using var memoryStream = new MemoryStream();
         using var cryptoStream = new CryptoStream(memoryStream, transform, CryptoStreamMode.Write);
-        using (var streamWriter = new StreamWriter(cryptoStream))
-        {
-            streamWriter.Write(data);
-        }
+        cryptoStream.Write(data, 0, data.Length);
+        cryptoStream.FlushFinalBlock();
 
         return memoryStream.ToArray();
     }
 
     public byte[] Decrypt(byte[] data, byte[] iv, byte[] key)
     {
-        if (data is null || !data.Any())
+        if (data is null || data.Length == 0)
         {
             throw new ArgumentException("Data to be decrypted cannot be empty.", nameof(data));
         }
 
-        if (iv is null || !iv.Any())
+        if (iv is null || iv.Length == 0)
         {
             throw new ArgumentException("Initialization vector cannot be empty.", nameof(iv));
         }
 
-        if (key is null || !key.Any())
+        if (key is null || key.Length == 0)
         {
             throw new ArgumentException("Encryption key cannot be empty.", nameof(key));
         }


### PR DESCRIPTION
This pull request refactors the encryption and decryption functionality in the `Convey.Security` namespace. The changes focus on removing redundant methods, simplifying logic, and improving performance by directly working with byte arrays instead of streams where possible.

### Refactoring and Simplification:

* Removed `Encrypt(string data, string key)` and `Decrypt(string data, string key)` methods from `IEncryptor` interface, focusing only on byte-based encryption and decryption for better flexibility and performance. (`src/Convey.Security/src/Convey.Security/IEncryptor.cs`)
* Updated `Encrypt(byte[] data, byte[] iv, byte[] key)` and `Decrypt(byte[] data, byte[] iv, byte[] key)` methods to use `cryptoStream.Write` and `cryptoStream.FlushFinalBlock` directly, eliminating unnecessary stream writer usage for improved efficiency. (`src/Convey.Security/src/Convey.Security/Internals/Encryptor.cs`) [[1]](diffhunk://#diff-9940a1b61b80a9074d1352a93e875581e53988abcd364395c567f9c8986dbe15L83-R50) [[2]](diffhunk://#diff-9940a1b61b80a9074d1352a93e875581e53988abcd364395c567f9c8986dbe15L112-R60)

### Code Quality Improvements:

* Replaced `.Any()` checks with `.Length == 0` for better readability and performance when validating input arrays. (`src/Convey.Security/src/Convey.Security/Internals/Encryptor.cs`)

These changes streamline the encryption module, making it more efficient and easier to maintain.